### PR TITLE
Remove jupyterlab server password for local development through docker

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,4 +19,4 @@ echo "Jupyter kernel installed."
 
 # Start Jupyter lab
 echo "Starting Jupyter lab..."
-uv run jupyter lab --no-browser --port=8888 --ip=0.0.0.0
+uv run jupyter lab --no-browser --port=8888 --ip=0.0.0.0 --ServerApp.token=''


### PR DESCRIPTION
# Fix

# Short Description
The setup script was running Jupyter Lab with password which disables access to it on Coder. Modified it to be a passwordless server.